### PR TITLE
Adding Github / SSH Keys section

### DIFF
--- a/BasicDapp.md
+++ b/BasicDapp.md
@@ -6,7 +6,7 @@ Moving on to our next tutorial, let's create our first dapp using **crypti-cli**
 
 Before we start, we first need a publicly accessible repository to store our dapp source code.
 
-Sign up or log into your [GitHub](https://github.com/) account, and [create a new public repository](https://help.github.com/articles/create-a-repo/) using a name of your choosing.
+[Sign up](https://github.com/join) or [log into](https://github.com/login) your [GitHub](https://github.com/) account, and [create a new public repository](https://help.github.com/articles/create-a-repo/) using a name of your choosing.
 
 #### Unique Genesis Block
 

--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -69,6 +69,17 @@ By default, Vagrant synchronizes your project directory between the local machin
 
 For further information about using vagrant, please read the [official vagrant documentation](https://docs.vagrantup.com/v2/).
 
+## Github / SSH Keys
+
+If you don't have a Github account already, then we would recommend [signing up](https://github.com/join) for one, before proceeding any further.
+
+Please also ensure, you have a public / private SSH keypair installed within the operating system you are developing on, and that the public key has been added to your Github account.
+
+To verify you have them installed, or generate a new keypair. Please read the appropriate Github help page, for the operating system you are developing on:
+
+* [Generating SSH keys on Mac OS X](https://help.github.com/articles/generating-ssh-keys/#platform-mac)
+* [Generating SSH keys on Linux](https://help.github.com/articles/generating-ssh-keys/#platform-linux)
+
 ## Install Crypti
 
 To start work on our dapp, we first need to install an **Open Testnet** version of Crypti. This can be done by running the following commands:

--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -69,13 +69,13 @@ By default, Vagrant synchronizes your project directory between the local machin
 
 For further information about using vagrant, please read the [official vagrant documentation](https://docs.vagrantup.com/v2/).
 
-## Github / SSH Keys
+## GitHub / SSH Keys
 
-If you don't have a Github account already, then we would recommend [signing up](https://github.com/join) for one, before proceeding any further.
+If you don't have a GitHub account already, then we would recommend [signing up](https://github.com/join) for one, before proceeding any further.
 
-Please also ensure, you have a public / private SSH keypair installed within the operating system you are developing on, and that the public key has been added to your Github account.
+Please also ensure, you have a public / private SSH keypair installed within the operating system you are developing on, and that the public key has been added to your GitHub account.
 
-To verify you have them installed, or generate a new keypair. Please read the appropriate Github help page, for the operating system you are developing on:
+To verify you have them installed, or generate a new keypair. Please read the appropriate GitHub help page, for the operating system you are developing on:
 
 * [Generating SSH keys on Mac OS X](https://help.github.com/articles/generating-ssh-keys/#platform-mac)
 * [Generating SSH keys on Linux](https://help.github.com/articles/generating-ssh-keys/#platform-linux)


### PR DESCRIPTION
- Adding a recommendation to sign up for a Github account.
- Adding link to Github help pages on how to generate SSH keys.
- Title casing references to "GitHub.
- Adding sign up and login links for Github.