### PR TITLE
Updating documentation for "Gaia" release

### DIFF
--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -35,7 +35,7 @@ Please ensure the below requirements are met before continuing.
     brew link sqlite --force
     ```
 
-**One important note**: Crypti's VM (Virtual Machine) is only sandboxed on Linux operating systems. **Mac OS X** can be used for development purposes, **but in production you will need to use Linux based master nodes**.
+**One important note**: Crypti's VM (Virtual Machine) is only sandboxed on Ubuntu Linux operating systems. **Mac OS X** can be used for development purposes, **but in production you will need to use Ubuntu Linux based master nodes**.
 
 ## Ubuntu Linux
 
@@ -61,7 +61,7 @@ Open a command prompt and proceed with the following:
 
 ## Windows _(using Vagrant)_
 
-Currently we only support development on Mac OS X and Linux operating systems. If you don't have either, see below for instructions on installing a Ubuntu based virtual machine using [Vagrant](https://www.vagrantup.com/).
+Currently we only support development on Mac OS X and Ubuntu Linux operating systems. If you don't have either, see below for instructions on installing a Ubuntu based virtual machine using [Vagrant](https://www.vagrantup.com/).
 
 1. Download and install the latest versions of the following applications:
 
@@ -170,7 +170,7 @@ cd 0.5.2
 npm install --production
 ```
 
-On **Linux** operating systems (or vagrant):
+On **Ubuntu Linux** operating systems (or vagrant):
 
 **TIP:** If using vagrant, it is a good idea to change to the shared: `/vagrant` directory as described above. This way, you can easily access your dapp's files from within the host operating system.
 

--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -103,14 +103,14 @@ Currently we only support development on Mac OS X and Linux operating systems. I
 3. Initialize a new Ubuntu based virtual machine using vagrant:
 
   ```sh
-  vagrant init ubuntu/trusty32
+  vagrant init ubuntu/trusty64
   ```
 
 4. Open and edit the file named `Vagrantfile` as follows:
 
   ```
   Vagrant.configure(2) do |config|
-    config.vm.box = "ubuntu/trusty32"
+    config.vm.box = "ubuntu/trusty64"
     config.vm.network "forwarded_port", guest: 7040, host: 7040
 
     config.vm.provider "virtualbox" do |vb|
@@ -125,7 +125,7 @@ Currently we only support development on Mac OS X and Linux operating systems. I
  vagrant up
  ```
 
- Once the virtual machine has finished installing, you should have a fully functioning environment running Ubuntu 14.04 LTS 32-bit.
+ Once the virtual machine has finished installing, you should have a fully functioning environment running Ubuntu 14.04 LTS 64-bit.
 
 6. Verify the status of the virtual machine using the following command:
 

--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -4,7 +4,7 @@ Before we can start building our first Crypti dapp, we must first setup our deve
 
 Please ensure the below requirements are met before continuing.
 
-* Mac OS X or Linux
+* Mac OS X or Ubuntu Linux
 * [Nodejs](https://nodejs.org/dist/latest-v0.12.x/) (v0.12)
 * [SQLite](https://www.sqlite.org/download.html) (v3.8)
 * [Npm](https://www.npmjs.com/)
@@ -37,31 +37,7 @@ Please ensure the below requirements are met before continuing.
 
 **One important note**: Crypti's VM (Virtual Machine) is only sandboxed on Linux operating systems. **Mac OS X** can be used for development purposes, **but in production you will need to use Linux based master nodes**.
 
-## Linux
-
-### Fedora Linux
-
-Open a command prompt and proceed with the following:
-
-1. Install **sqlite** and **git** plus some build essentials.
-
-  ```
-  sudo yum install -y sqlite git gcc-c++ make curl wget unzip
-  ```
-
-2. Add the NodeSource package repository to your system.
-
-  ```
-  curl -sL https://rpm.nodesource.com/setup_0.12 | sudo -E bash -
-  ```
-
-3. Install **nodejs** (package also includes **npm**).
-
-  ```
-  sudo yum install -y nodejs
-  ```
-
-### Ubuntu Linux
+## Ubuntu Linux
 
 Open a command prompt and proceed with the following:
 

--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -164,9 +164,9 @@ To start work on our dapp, we first need to install a **testnet** version of Cry
 On **Mac OS X** operating systems:
 
 ```sh
-wget http://downloads.crypti.me/crypti-node/development/macos-0.5.1.zip
-unzip macos-0.5.1.zip
-cd 0.5.1
+wget http://downloads.crypti.me/crypti-node/development/macos-0.5.2.zip
+unzip macos-0.5.2.zip
+cd 0.5.2
 npm install --production
 ```
 
@@ -175,9 +175,9 @@ On **Linux** operating systems (or vagrant):
 **TIP:** If using vagrant, it is a good idea to change to the shared: `/vagrant` directory as described above. This way, you can easily access your dapp's files from within the host operating system.
 
 ```sh
-wget http://downloads.crypti.me/crypti-node/development/linux-0.5.1.zip
-unzip linux-0.5.1.zip
-cd 0.5.1
+wget http://downloads.crypti.me/crypti-node/development/linux-0.5.2.zip
+unzip linux-0.5.2.zip
+cd 0.5.2
 npm install --production
 ```
 


### PR DESCRIPTION
- Specifying trusty/64 instead of trusty/32.
- Removing Fedora Linux; Specifying only Ubuntu Linux for now.
- Bumping version numbers.